### PR TITLE
Rewrite output file rather than infinitely appending

### DIFF
--- a/src/BetterJSONStorage/BetterJSONStorage.py
+++ b/src/BetterJSONStorage/BetterJSONStorage.py
@@ -152,6 +152,7 @@ class BetterJSONStorage:
 
             if self._changed:
                 self._changed = False
+                self._handle.seek(0)
                 self._handle.write(compress(dumps(self._data)))
 
         self._shutdown_lock.release()


### PR DESCRIPTION
At the current state this extension did two terrible things:
- it bloated up the output file by _appending_ the complete new output that was supposed to replace the file
- reading the resulting database file resulting in obtaining the _first_ version that was ever written and discarding all further updates (that were just appended)

This seek fixes both of these issues.