### PR TITLE
Don't start file write if not needed

### DIFF
--- a/src/BetterJSONStorage/BetterJSONStorage.py
+++ b/src/BetterJSONStorage/BetterJSONStorage.py
@@ -126,7 +126,9 @@ class BetterJSONStorage:
 
         # finishing init
         self.load()
-        Thread.start_new_thread(self.__file_writer, ())
+        # only start the file write at all if the access mode is not read only
+        if access_mode == "r+":
+            Thread.start_new_thread(self.__file_writer, ())
 
     def __new__(class_, path, *args, **kwargs):
         h = hash(path)


### PR DESCRIPTION
The file writer thread is a  100% CPU usage while loop that checks for file changes. This is questionable already and might be improved by a sleep interjection, but this is for another PR.

This PR simply suggests that if the access mode to the DB is "r" = read-only, then we do not need to run this 100% CPU load thread anyways.